### PR TITLE
Added Imprint page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,17 @@
 <hr>
 <!-- Footer -->
 <footer>
-    <div class="row">
-        <div class="col-lg-12">
-            <p>Copyright &copy; {{ site.time | date: '%Y' }}, {{ site.organization }}</p>
-        </div>
+   <div class="row">
+      <div class="col-md-6">
+        <p>Copyright &copy; {{ site.time | date: '%Y' }}, {{ site.organization }}</p>
+      </div>
+      <div class="col-md-6">
+         <nav role="navigation">
+            <ul class="list-inline pull-right">
+               <li><a href="/imprint">Imprint</a></li>
+               <li><a href="/privacy">Privacy Policy</a></li>
+            </ul>
+         </nav>
+      </div>
     </div>
 </footer>

--- a/imprint.html
+++ b/imprint.html
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Imprint
+---
+<!-- Page Heading/Breadcrumbs -->
+<div class="row">
+    <div class="col-lg-12">
+        <h1 class="page-header">Imprint
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="index.html">Home</a>
+            </li>
+            <li class="active">Imprint</li>
+        </ol>
+    </div>
+</div>
+<!-- Content Row -->
+<div class="row">
+   <section class="col-md-12">
+     <h3>This site is owned and operated by</h3>
+     <address>
+        <p>openHAB Foundation e.V.<br />Kollwitzweg 10<br />64372 Ober-Ramstadt</p>
+     </address>
+     <p><i class="fa fa-phone"></i> +49 (6154) 603-9765</p>
+     <p><i class="fa fa-envelope-o"></i> <a href="mailto:info@openhabfoundation.org">info@openhabfoundation.org</a></p>
+     <h3>Executive Board</h3>
+     <p>Kai Kreuzer, President<br />Dan Cunningham, Vice President<br />Hans-Jörg Merk, Chief Financial Officer</p>
+     <p>Register of Associations: Darmstadt 83855</p>
+     <h3>Privacy Statement</h3>
+     <p>openHAB Foundation respects your desire for privacy. Please see our <a href="/privacy">Privacy Policy</a> regarding the use of our website and the mobile reference applications.</p>
+     <h3>Trademarks</h3>
+     <p>openHAB is a registered trademark of Kai Kreuzer in Germany and other countries.</p>
+  </section>
+</div>


### PR DESCRIPTION
The imprint was created after the imprint on the GI website (https://en.gi.de/startpage/imprint.html).

Added (at least basic) trademark information to the imprint.

Links to imprint and privacy policy added to the footer line (imprint must be directly accessible with a "single click" but main menu was IMHO too "prominent").