### PR TITLE
Musala Soft E-mail is Now openHAB Specific

### DIFF
--- a/members/_posts/2017-01-12-musala.md
+++ b/members/_posts/2017-01-12-musala.md
@@ -8,7 +8,7 @@ address1: 'World Trade Center 36, Dragan Tsankov blvd.'
 city: 'Sofia 1057'
 country: 'Bulgaria'
 web: http://www.musala.com/
-email: musala@musala.com
+email: openHAB@musala.com
 github: MusalaSoft
 twitter: musalasoft
 phone: +359 (2) 969 5821


### PR DESCRIPTION
We have created specific e-mail group for our openHAB membership.  The e-mail in Musala Soft's membership page is now the openHAB specific one.