### PR TITLE
Updated docs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@ System-wide, multi-vendor interoperability can only succeed if it is free from m
             </div>
             <div class="media-body">
                 <h4 class="media-heading">Reference Documentation</h4>
-                <p>As documentation is often scarse, we help on providing a detailed <a href="http://docs.openhab.org/introduction.html">user reference</a>.</p>
+                <p>As documentation is often scarse, we help on providing a detailed <a href="https://www.openhab.org/docs/">user reference</a>.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Just something i saw while browsing around.

Should we change the tutorials url to the showcase section too maybe?

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>